### PR TITLE
add list command

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import type { LocalContext } from './context.js';
 import { addChatCommand } from './commands/chat/chatCommand.js';
 import { addExecCommand } from './commands/exec/execCommand.js';
+import { addListCommand } from './commands/list/listCommand.js';
 
 function increaseVerbosity(dummyValue: string, previous: number) {
   return previous + 1;
@@ -15,5 +16,6 @@ export function createPal(context: LocalContext) {
     .option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0)
   addChatCommand(pal, context)
   addExecCommand(pal, context)
+  addListCommand(pal, context)
   return pal;
 }

--- a/src/commands/chat/chatHandler.ts
+++ b/src/commands/chat/chatHandler.ts
@@ -1,7 +1,4 @@
-import { ScriptManager, type Command } from "../../data/scriptManager";
-import { MockLLMService } from "../../data/llm";
-import { UserInteraction } from "../../data/interaction";
-import { spawn } from "node:child_process";
+import { type Command } from "../../data/scriptManager";
 import type { LocalContext } from "../../context";
 
 interface ChatOptions {
@@ -93,23 +90,3 @@ async function handleNewScript(
     context.process.stderr.write(`Error generating script: ${error}\n`);
   }
 }
-
-async function executeScript(scriptPath: string, context: LocalContext): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn("bash", [scriptPath], {
-      stdio: "inherit",
-      cwd: context.process.cwd(),
-    });
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`Script exited with code ${code}`));
-      }
-    });
-    child.on("error", (error) => {
-      reject(error);
-    });
-  });
-}
-

--- a/src/commands/exec/execHandler.ts
+++ b/src/commands/exec/execHandler.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import type { LocalContext } from "../../context";
 
 interface ExecOptions {

--- a/src/commands/list/listCommand.ts
+++ b/src/commands/list/listCommand.ts
@@ -1,0 +1,12 @@
+import type { Command } from "commander";
+import listHandler from "./listHandler";
+import type { LocalContext } from "../../context";
+
+export function addListCommand(pal: Command, context: LocalContext): Command {
+  pal.command('list')
+    .description("List all saved scripts with descriptions")
+    .action(async () => {
+      await listHandler({ context });
+    });
+  return pal;
+}

--- a/src/commands/list/listHandler.ts
+++ b/src/commands/list/listHandler.ts
@@ -1,0 +1,21 @@
+import type { LocalContext } from "../../context";
+
+interface ListHandlerOptions {
+  context: LocalContext;
+}
+
+export default async function listHandler({ context }: ListHandlerOptions): Promise<void> {
+  const commands = context.scriptManager.getAllCommands();
+  
+  if (commands.length === 0) {
+    context.process.stdout.write("No scripts found.\n");
+    return;
+  }
+
+  context.process.stdout.write(`Found ${commands.length} script(s):\n\n`);
+  
+  for (const command of commands) {
+    context.process.stdout.write(`${command.name}\n`);
+    context.process.stdout.write(`  ${command.description}\n\n`);
+  }
+}

--- a/src/data/scriptManager.ts
+++ b/src/data/scriptManager.ts
@@ -39,6 +39,10 @@ export class ScriptManager {
     return this.manifest.commands[path]
   }
 
+  getAllCommands(): Command[] {
+    return Object.values(this.manifest.commands);
+  }
+
   private static async ensureDirectories(commandDir: string): Promise<void> {
     await fs.promises.mkdir(commandDir, { recursive: true });
   }


### PR DESCRIPTION
1. Created the command structure in /src/commands/list/ with:
   • listCommand.ts - Command definition and registration
   • listHandler.ts - Core logic to read and display scripts

2. Added a new method to ScriptManager:
   • getAllCommands() - Returns all commands from the manifest

3. Integrated the command into the main app by:
   • Importing the addListCommand function
   • Adding it to the command registration in createPal()

4. The command displays:
   • Total count of scripts found
   • Each script name and description in a clean format
   • Handles empty manifest gracefully

```
  $ pal --help
Usage: pal [options] [command]

Your agentic terminal friend

Options:
  -V, --version               output the version number
  -v, --verbose               verbosity that can be increased
  -h, --help                  display help for command

Commands:
  chat [options] [prompt...]  Chat with pal AI to generate and execute commands
  exec [options] [prompt...]  Execute saved scripts with pal
  list                        List all saved scripts with descriptions
  help [command]              display help for command
  
  
  $ pal list
Found 1 script(s):

bash/killProcessWithListeningOnPort
  This script takes a port number as an argument and attempts to kill the process listening on that port. It first checks for a valid port number, then uses `lsof` or `netstat` to find the process ID (PID). Finally, it uses the `kill -9` command to forcefully terminate the process and verifies if the process was successfully killed.
```
